### PR TITLE
Add failing spec for bug and some related passing specs

### DIFF
--- a/spec/config_mapper/config_struct_spec.rb
+++ b/spec/config_mapper/config_struct_spec.rb
@@ -57,6 +57,69 @@ describe ConfigMapper::ConfigStruct do
 
     end
 
+    context "declared with a block and a default value" do
+
+      with_target_class do
+        attribute :port, :default => 5000, &method(:Integer)
+      end
+
+      context "and no override provided" do
+
+        it "defaults to the specified value" do
+          expect(target.port).to eql(5000)
+        end
+
+        it "invokes the block to validate the default value" do
+          expect { target.port = "abc" }.to raise_error(ArgumentError)
+        end
+
+      end
+
+      context "with overridden value" do
+
+        it "assigns the return value to the attribute" do
+          target.port = 456
+          expect(target.port).to eql(456)
+        end
+
+        it "invokes the block to validate the override value" do
+          expect { target.port = "abc" }.to raise_error(ArgumentError)
+        end
+
+      end
+
+      context "with an optional value" do
+
+        with_target_class do
+          attribute :port, :default => nil, &method(:Integer)
+        end
+
+        it "assigns the return value to the attribute" do
+          target.port = 456
+          expect(target.port).to eql(456)
+        end
+
+        it "invokes the block to validate the override value" do
+          expect { target.port = "abc" }.to raise_error(ArgumentError)
+        end
+
+        context "and an explicit nil value" do
+
+          with_target_class do
+            attribute :port, :default => nil, &method(:Integer)
+          end
+
+          it "assigns the return value to the attribute" do
+            target.port = nil
+            expect(target.port).to eql(nil)
+          end
+
+        end
+
+      end
+
+    end
+
   end
 
   context "with a .component" do


### PR DESCRIPTION
This is either some broken behavior, or just me not using config_struct as intended.

The problem is in the special handling of nil default values in config mapper that treats them as optional values.

The first commit in this PR adds some specs that illustrate some conditions seen in real usage of this library under which using nil to represent "optional" breaks down, and some passing specs that can possibly be removed but will need to pass successfully for a valid solution.
