### PR TITLE
Component list

### DIFF
--- a/lib/config_mapper.rb
+++ b/lib/config_mapper.rb
@@ -1,5 +1,6 @@
 require "config_mapper/collection_mapper"
 require "config_mapper/config_dict"
+require "config_mapper/config_list"
 require "config_mapper/object_mapper"
 
 # Supports marshalling of plain-old data (e.g. loaded from

--- a/lib/config_mapper/config_list.rb
+++ b/lib/config_mapper/config_list.rb
@@ -1,0 +1,82 @@
+require 'config_mapper'
+require 'config_mapper/config_struct'
+require "config_mapper/factory"
+require "config_mapper/validator"
+require "forwardable"
+
+module ConfigMapper
+  class ConfigStruct
+    def self.component_list(name, type: ConfigStruct, description: nil, &block)
+      type = Class.new(type, &block) if block
+      component(name, type: ConfigList::Factory.new(type), description: description)
+    end
+  end
+
+  class ConfigList
+
+    class Factory
+
+      def initialize(entry_factory)
+        @entry_factory = ConfigMapper::Factory.resolve(entry_factory)
+      end
+
+      attr_reader :entry_factory
+
+      def new
+        ConfigList.new(@entry_factory)
+      end
+
+      def config_doc
+        return {} unless entry_factory.respond_to?(:config_doc)
+        {}.tap do |result|
+          entry_factory.config_doc.each do |path, doc|
+            result["[N]#{path}"] = doc
+          end
+        end
+      end
+
+    end
+
+    def initialize(entry_factory)
+      @entry_factory = entry_factory
+      @entries = []
+    end
+
+    def [](index)
+      @entries[index] ||= @entry_factory.new
+    end
+
+    def to_a
+      map do |element|
+        case
+          when element.respond_to?(:to_h); element.to_h
+          when element.respond_to?(:to_a); element.to_a
+          else element
+        end
+      end
+    end
+
+    # TODO: ConfigStruct#to_h needs to call to_a when something looks like an array
+    def to_h; to_a end
+
+    def config_errors
+      {}.tap do |errors|
+        each_with_index do |element, index|
+          next unless element.respond_to?(:config_errors)
+          prefix = "[#{index}]"
+          element.config_errors.each do |path, path_errors|
+            errors["#{prefix}#{path}"] = path_errors
+          end
+        end
+      end
+    end
+
+    extend Forwardable
+
+    def_delegators :@entries, :each, :each_with_index, :empty?, :map, :size
+
+    include Enumerable
+
+  end
+end
+

--- a/lib/config_mapper/config_list.rb
+++ b/lib/config_mapper/config_list.rb
@@ -5,13 +5,6 @@ require "config_mapper/validator"
 require "forwardable"
 
 module ConfigMapper
-  class ConfigStruct
-    def self.component_list(name, type: ConfigStruct, description: nil, &block)
-      type = Class.new(type, &block) if block
-      component(name, type: ConfigList::Factory.new(type), description: description)
-    end
-  end
-
   class ConfigList
 
     class Factory
@@ -55,9 +48,6 @@ module ConfigMapper
         end
       end
     end
-
-    # TODO: ConfigStruct#to_h needs to call to_a when something looks like an array
-    def to_h; to_a end
 
     def config_errors
       {}.tap do |errors|

--- a/lib/config_mapper/config_struct.rb
+++ b/lib/config_mapper/config_struct.rb
@@ -89,6 +89,19 @@ module ConfigMapper
         component(name, type: ConfigDict::Factory.new(type, key_type), description: description)
       end
 
+      # Defines an array of sub-components.
+      #
+      # If a block is be provided, it will be `class_eval`ed to define the
+      # sub-components class.
+      #
+      # @param name [Symbol] list attribute name
+      # @param type [Class] base-class for component values
+      #
+      def component_list(name, type: ConfigStruct, description: nil, &block)
+        type = Class.new(type, &block) if block
+        component(name, type: ConfigList::Factory.new(type), description: description)
+      end
+
       # Generate documentation, as Ruby data.
       #
       # Returns an entry for each configurable path, detailing
@@ -159,6 +172,8 @@ module ConfigMapper
           value = send(attribute.name)
           if value && value.respond_to?(:to_h) && !value.is_a?(Array)
             value = value.to_h
+          elsif value && value.respond_to?(:to_a)
+            value = value.to_a
           end
           result[attribute.name.to_s] = value
         end

--- a/spec/config_mapper/config_list_spec.rb
+++ b/spec/config_mapper/config_list_spec.rb
@@ -1,6 +1,6 @@
-require "config_mapper/config_dict"
+require "config_mapper/config_list"
 
-describe ConfigMapper::ConfigDict do
+describe ConfigMapper::ConfigList do
 
   let(:entry_class) { Struct.new(:x, :y) }
 

--- a/spec/config_mapper/config_list_spec.rb
+++ b/spec/config_mapper/config_list_spec.rb
@@ -1,0 +1,39 @@
+require "config_mapper/config_dict"
+
+describe ConfigMapper::ConfigDict do
+
+  let(:entry_class) { Struct.new(:x, :y) }
+
+  subject(:list) { ConfigMapper::ConfigList.new(entry_class) }
+
+  it "looks like an array" do
+    expect(list).to respond_to(:[])
+  end
+
+  it "starts empty" do
+    expect(list).to be_empty
+  end
+
+  it "creates entries on access" do
+    expect(list[0]).to_not be_nil
+  end
+
+  it "uses the entry_class to generate new values" do
+    expect(list[0]).to be_kind_of(entry_class)
+  end
+
+  it "implements []" do
+    list[0].x = 1
+    expect(list[0].x).to eql(1)
+  end
+
+  it "can be enumerated" do
+    list[0].x = 1
+    x_values = []
+    list.each_with_index do |item, index|
+      x_values[index] = item.x
+    end
+    expect(x_values).to eql([1])
+  end
+
+end


### PR DESCRIPTION
This implements the code required for https://github.com/mdub/config_mapper/issues/6

However, there are some limitations that I remains unimplemented. Basically with this code you can create the following:

```ruby
class Config < ConfigMapper::ConfigStruct

  component_list :people do
    attribute :name, String
    attribute :age, Integer, default: 21

    component_dict :beers do
      attribute :ranking, Integer
      attribute :brewery, String
    end
  end

end
```

But, I can't make it do basic lists with validation. E.g. a very basic array of strings.

```ruby
class Config < ConfigMapper::ConfigStruct

  component_list :people do
    attribute :name, String
    attribute :age, Integer, default: 21

    component_list :superpowers, type: String
  end

end
```

Where in the above example, the config data might look like this:

```ruby
[
  { 'name' => 'dan', 'age' => 18, 'superpowers' => [ 'youth', 'invisibility' ] }
  { 'name' => 'mike', 'superpowers' => [ 'flying', 'coding' ] }
]
```

With this config data, we might want to validate the members of the array are `String`, in the same way you can for `attribute`. At least that was the original intention for people able to pass a `type` to `component_list`. I can't make it work though :'(