### PR TITLE
Component list to h

### DIFF
--- a/lib/config_mapper/config_struct.rb
+++ b/lib/config_mapper/config_struct.rb
@@ -170,7 +170,7 @@ module ConfigMapper
       {}.tap do |result|
         self.class.each_attribute do |attribute|
           value = send(attribute.name)
-          if value && value.respond_to?(:to_h) && !value.is_a?(Array)
+          if value && value.respond_to?(:to_h) && !value.is_a?(Array) && !value.is_a?(ConfigList)
             value = value.to_h
           elsif value && value.respond_to?(:to_a)
             value = value.to_a

--- a/spec/config_mapper/config_struct_spec.rb
+++ b/spec/config_mapper/config_struct_spec.rb
@@ -486,6 +486,9 @@ describe ConfigMapper::ConfigStruct do
       component_dict :services do
         attribute :port
       end
+      component_list :aliases do
+        attribute :alias
+      end
       attribute :words
     end
 
@@ -517,6 +520,22 @@ describe ConfigMapper::ConfigStruct do
             "port" => 5678
           }
         }
+      }
+      expect(target.to_h).to include(expected)
+    end
+
+    it "includes component_lists" do
+      target.aliases[0].alias = "fred"
+      target.aliases[1].alias = "jane"
+      expected = {
+        "aliases" => [
+          {
+            "alias" => "fred"
+          },
+          {
+            "alias" => "jane"
+          }
+        ]
       }
       expect(target.to_h).to include(expected)
     end


### PR DESCRIPTION
When attempting to `to_h` a class extending `ConfigMapper::ConfigStruct` which included a `component_list` I got an exception:

```
     TypeError:
       wrong element type #<Class:0x007ff1d2900b98> (expected array)
     # ./lib/config_mapper/config_struct.rb:174:in `to_h'
     # ./lib/config_mapper/config_struct.rb:174:in `block (2 levels) in to_h'
```

After some digging I tracked this down and made the associated change. I'm not a huge fan of this solution but with Ruby's Enumerable interface implementing both `to_a` and `to_h` it seem workable for now (feedback welcome).